### PR TITLE
refactor: relocate Project model and unify frontmatter parsing

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,22 +2,24 @@ import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_router/jaspr_router.dart';
 
-import 'content.dart' as content;
+import 'models/data_model.dart';
 import 'pages/about.dart';
 import 'pages/home.dart';
 import 'pages/post_page.dart';
 import 'pages/projects_page.dart';
 import 'pages/static_outputs.dart';
-import 'projects_content.dart' as projects_content;
 
 class App extends StatelessComponent {
-  const App({super.key});
+  final List<Post> posts;
+  final List<Project> projects;
+
+  const App({required this.posts, required this.projects, super.key});
 
   @override
   Component build(BuildContext context) {
     // Dynamically compile post routes from our parsed content database
-    final postRoutes = content.posts
-        .where((post) => post.flavor == content.EntryFlavor.writing)
+    final postRoutes = posts
+        .where((post) => post.flavor == EntryFlavor.writing)
         .map(
           (post) => Route(
             path: post.permalink,
@@ -33,7 +35,7 @@ class App extends StatelessComponent {
           Route(
             path: '/',
             title: 'kevmoo @ Work',
-            builder: (context, state) => const Home(),
+            builder: (context, state) => Home(posts: posts),
           ),
           Route(
             path: '/about',
@@ -43,8 +45,7 @@ class App extends StatelessComponent {
           Route(
             path: '/projects',
             title: 'Projects | kevmoo @ Work',
-            builder: (context, state) =>
-                ProjectsPage(projects: projects_content.projects),
+            builder: (context, state) => ProjectsPage(projects: projects),
           ),
           Route(
             path: '/feed.xml',

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,8 +12,14 @@ import 'pages/static_outputs.dart';
 class App extends StatelessComponent {
   final List<Post> posts;
   final List<Project> projects;
+  final String aboutContentHtml;
 
-  const App({required this.posts, required this.projects, super.key});
+  const App({
+    required this.posts,
+    required this.projects,
+    required this.aboutContentHtml,
+    super.key,
+  });
 
   @override
   Component build(BuildContext context) {
@@ -40,7 +46,7 @@ class App extends StatelessComponent {
           Route(
             path: '/about',
             title: 'About | kevmoo @ Work',
-            builder: (context, state) => const About(),
+            builder: (context, state) => About(contentHtml: aboutContentHtml),
           ),
           Route(
             path: '/projects',

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,6 +8,7 @@ import 'pages/home.dart';
 import 'pages/post_page.dart';
 import 'pages/projects_page.dart';
 import 'pages/static_outputs.dart';
+import 'projects_content.dart' as projects_content;
 
 class App extends StatelessComponent {
   const App({super.key});
@@ -42,7 +43,8 @@ class App extends StatelessComponent {
           Route(
             path: '/projects',
             title: 'Projects | kevmoo @ Work',
-            builder: (context, state) => const ProjectsPage(),
+            builder: (context, state) =>
+                ProjectsPage(projects: projects_content.projects),
           ),
           Route(
             path: '/feed.xml',

--- a/lib/components/footer.dart
+++ b/lib/components/footer.dart
@@ -1,6 +1,6 @@
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
-import '../content.dart' as content;
+import '../models/data_model.dart';
 
 class Footer extends StatelessComponent {
   const Footer({super.key});
@@ -25,7 +25,7 @@ class Footer extends StatelessComponent {
                   'flex items-center space-x-6 text-slate-400 '
                   'dark:text-slate-500',
               [
-                for (final link in content.socialLinks)
+                for (final link in socialLinks)
                   a(
                     href: link.href,
                     target: Target.blank,

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -5,6 +5,7 @@ import 'package:xml/xml.dart';
 import 'package:yaml/yaml.dart';
 import 'constants.dart';
 import 'models/data_model.dart';
+import 'server/content_parser.dart';
 
 export 'models/data_model.dart';
 
@@ -101,25 +102,8 @@ final _fileDateRegExp = RegExp(r'^(\d{4})-(\d{2})-(\d{2})-(.+)\.(md|html)$');
 final _markdownCleanupRegExp = RegExp(r'\{:\s*[^}]*\}');
 
 Post _parseJekyllPost(String filePath, String filename, String content) {
-  if (!content.startsWith('---')) {
-    throw FormatException(
-      'File does not start with Jekyll frontmatter '
-      'delimiter (---) in $filePath',
-    );
-  }
-
-  final parts = content.split('---');
-  if (parts.length < 3) {
-    throw FormatException(
-      'Malformed Jekyll frontmatter (missing closing ---) '
-      'in $filePath',
-    );
-  }
-
-  final frontmatterString = parts[1];
-  final bodyContent = parts.sublist(2).join('---').trim();
-
-  final yaml = loadYaml(frontmatterString) as YamlMap;
+  final parsed = parseFrontmatterString(content);
+  final yaml = parsed.frontmatter;
   final title = yaml['title']?.toString() ?? 'Untitled';
 
   // Extract date from filename
@@ -161,9 +145,12 @@ Post _parseJekyllPost(String filePath, String filename, String content) {
 
   var contentHtml = '';
   if (isHtml) {
-    contentHtml = bodyContent;
+    contentHtml = parsed.bodyMarkdown;
   } else {
-    final cleanedBody = bodyContent.replaceAll(_markdownCleanupRegExp, '');
+    final cleanedBody = parsed.bodyMarkdown.replaceAll(
+      _markdownCleanupRegExp,
+      '',
+    );
     contentHtml = md.markdownToHtml(
       cleanedBody,
       extensionSet: md.ExtensionSet.gitHubFlavored,

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -102,7 +102,7 @@ final _fileDateRegExp = RegExp(r'^(\d{4})-(\d{2})-(\d{2})-(.+)\.(md|html)$');
 final _markdownCleanupRegExp = RegExp(r'\{:\s*[^}]*\}');
 
 Post _parseJekyllPost(String filePath, String filename, String content) {
-  final parsed = parseFrontmatterString(content);
+  final parsed = parseFrontmatterString(content, requireFrontmatter: true);
   final yaml = parsed.frontmatter;
   final title = yaml['title']?.toString() ?? 'Untitled';
 

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -303,3 +303,15 @@ String generateSitemap() {
 }
 
 String _formatIso8601(DateTime date) => date.toUtc().toIso8601String();
+
+String loadAboutContent() {
+  try {
+    final file = File('_pages/about.md');
+    if (file.existsSync()) {
+      return parseFrontmatterFile(file).bodyHtml;
+    }
+  } catch (e) {
+    print('Error loading about.md: $e');
+  }
+  return '';
+}

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -303,16 +303,3 @@ String generateSitemap() {
 }
 
 String _formatIso8601(DateTime date) => date.toUtc().toIso8601String();
-
-String normalizeTag(String tag) => switch (tag.toLowerCase()) {
-  'dartlang' || 'dart' => 'Dart',
-  'ruby on rails' || 'rails' => 'Rails',
-  '.net' => '.NET',
-  'c#' => 'CSharp',
-  'wpf' => 'WPF',
-  'xaml' => 'XAML',
-  'git' => 'Git',
-  'javascript' => 'JS',
-  _ when tag.length <= 3 => tag.toUpperCase(),
-  _ => tag[0].toUpperCase() + tag.substring(1),
-};

--- a/lib/main.server.dart
+++ b/lib/main.server.dart
@@ -93,7 +93,11 @@ void main() {
         ),
       ],
       styles: const [],
-      body: App(posts: content.posts, projects: projects_content.projects),
+      body: App(
+        posts: content.posts,
+        projects: projects_content.projects,
+        aboutContentHtml: content.loadAboutContent(),
+      ),
     ),
   );
 }

--- a/lib/main.server.dart
+++ b/lib/main.server.dart
@@ -3,7 +3,9 @@ import 'package:jaspr/server.dart';
 
 import 'app.dart';
 import 'constants.dart';
+import 'content.dart' as content;
 import 'main.server.options.dart';
+import 'projects_content.dart' as projects_content;
 
 void main() {
   Jaspr.initializeApp(
@@ -12,15 +14,15 @@ void main() {
   );
 
   runApp(
-    const Document(
+    Document(
       title: 'kevmoo @ Work',
-      meta: {
+      meta: const {
         'description':
             'Googler working on Dart and Flutter web technology. '
             'Thoughts, notes, and bag of tricks.',
         'viewport': 'width=device-width, initial-scale=1.0',
       },
-      head: [
+      head: const [
         // Google Analytics (gtag.js)
         Component.element(
           tag: 'script',
@@ -90,8 +92,8 @@ void main() {
           children: [],
         ),
       ],
-      styles: [],
-      body: App(),
+      styles: const [],
+      body: App(posts: content.posts, projects: projects_content.projects),
     ),
   );
 }

--- a/lib/models/data_model.dart
+++ b/lib/models/data_model.dart
@@ -136,3 +136,16 @@ const socialLinks = <SocialLink>[
     iconClass: 'fab fa-twitter',
   ),
 ];
+
+String normalizeTag(String tag) => switch (tag.toLowerCase()) {
+  'dartlang' || 'dart' => 'Dart',
+  'ruby on rails' || 'rails' => 'Rails',
+  '.net' => '.NET',
+  'c#' => 'CSharp',
+  'wpf' => 'WPF',
+  'xaml' => 'XAML',
+  'git' => 'Git',
+  'javascript' => 'JS',
+  _ when tag.length <= 3 => tag.toUpperCase(),
+  _ => tag[0].toUpperCase() + tag.substring(1),
+};

--- a/lib/models/data_model.dart
+++ b/lib/models/data_model.dart
@@ -61,6 +61,42 @@ class Post {
   });
 }
 
+class Project {
+  final String id;
+  final String name;
+  final String repo; // e.g. kevmoo/pubviz
+  final String? pubPackage; // e.g. pubviz
+  final String? installCommand;
+  final bool featured;
+  final bool ignore;
+  final List<String> relatedPostPermalinks;
+  final String contentHtml;
+  final String? latestVersion;
+  final int? githubStars;
+  final String? pubUrl;
+  final String? githubUrl;
+  final String? lastReviewedSha;
+  final DateTime? lastReviewedAt;
+
+  Project({
+    required this.id,
+    required this.name,
+    required this.repo,
+    this.pubPackage,
+    this.installCommand,
+    this.featured = false,
+    this.ignore = false,
+    this.relatedPostPermalinks = const [],
+    required this.contentHtml,
+    this.latestVersion,
+    this.githubStars,
+    this.pubUrl,
+    this.githubUrl,
+    this.lastReviewedSha,
+    this.lastReviewedAt,
+  });
+}
+
 typedef SocialLink = ({String href, String title, String iconClass});
 
 const socialLinks = <SocialLink>[

--- a/lib/pages/about.dart
+++ b/lib/pages/about.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
-import 'package:markdown/markdown.dart' as md;
 
 import '../components/footer.dart';
 import '../components/header.dart';
 import '../constants.dart';
+import '../server/content_parser.dart';
 
 class About extends StatelessComponent {
   const About({super.key});
@@ -18,22 +18,8 @@ class About extends StatelessComponent {
     try {
       final file = File('_pages/about.md');
       if (file.existsSync()) {
-        final content = file.readAsStringSync();
-        if (content.startsWith('---')) {
-          final parts = content.split('---');
-          if (parts.length >= 3) {
-            final body = parts.sublist(2).join('---').trim();
-            pageContentHtml = md.markdownToHtml(
-              body,
-              extensionSet: md.ExtensionSet.gitHubFlavored,
-            );
-          }
-        } else {
-          pageContentHtml = md.markdownToHtml(
-            content,
-            extensionSet: md.ExtensionSet.gitHubFlavored,
-          );
-        }
+        final parsed = parseFrontmatterFile(file);
+        pageContentHtml = parsed.bodyHtml;
       }
     } catch (e) {
       print('Error loading about.md: $e');

--- a/lib/pages/about.dart
+++ b/lib/pages/about.dart
@@ -1,29 +1,19 @@
-import 'dart:io';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
 import '../components/footer.dart';
 import '../components/header.dart';
 import '../constants.dart';
-import '../server/content_parser.dart';
 
 class About extends StatelessComponent {
-  const About({super.key});
+  final String contentHtml;
+
+  const About({required this.contentHtml, super.key});
 
   @override
   Component build(BuildContext context) {
-    var pageTitle = 'About';
-    var pageContentHtml = '';
-
-    try {
-      final file = File('_pages/about.md');
-      if (file.existsSync()) {
-        final parsed = parseFrontmatterFile(file);
-        pageContentHtml = parsed.bodyHtml;
-      }
-    } catch (e) {
-      print('Error loading about.md: $e');
-    }
+    const pageTitle = 'About';
+    var pageContentHtml = contentHtml;
 
     if (pageContentHtml.isEmpty) {
       pageContentHtml =
@@ -42,7 +32,7 @@ class About extends StatelessComponent {
         [
           const Header(activePath: '/about'),
           div(classes: 'max-w-2xl w-full mx-auto px-6 py-16 flex-1', [
-            h1(
+            const h1(
               classes:
                   'text-3xl font-black tracking-tight text-slate-950 '
                   'dark:text-white mb-8',

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -3,25 +3,25 @@ import 'package:jaspr/jaspr.dart';
 import '../components/header.dart';
 import '../components/interactive_post_list.dart';
 import '../constants.dart';
-import '../content.dart' as content;
 import '../models/client_post_item.dart';
+import '../models/data_model.dart';
 
 class Home extends StatelessComponent {
-  const Home({super.key});
+  final List<Post> posts;
+
+  const Home({required this.posts, super.key});
 
   @override
   Component build(BuildContext context) {
-    final posts = content.posts;
-
     final clientPosts = posts.map((post) {
-      final isWriting = post.flavor == content.EntryFlavor.writing;
+      final isWriting = post.flavor == EntryFlavor.writing;
       return ClientPostItem(
         permalink: post.permalink,
         title: post.title,
         subTitle: post.subTitle ?? '',
         dateString: _formatDate(post.date),
         year: post.date.year,
-        tags: post.tags.map(content.normalizeTag).toList(),
+        tags: post.tags.map(normalizeTag).toList(),
         awesomeHtml: post.flavor.awesome,
         isWriting: isWriting,
         linkUrl: isWriting ? post.permalink : (post.uri ?? ''),
@@ -88,7 +88,7 @@ class Home extends StatelessComponent {
                       'profiles flex justify-center gap-6 text-slate-400 '
                       'dark:text-slate-500',
                   [
-                    for (final link in content.socialLinks)
+                    for (final link in socialLinks)
                       _buildSocialLink(
                         link.href,
                         link.title,

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -4,10 +4,11 @@ import '../components/footer.dart';
 import '../components/header.dart';
 import '../constants.dart';
 import '../models/data_model.dart';
-import '../projects_content.dart';
 
 class ProjectsPage extends StatelessComponent {
-  const ProjectsPage({super.key});
+  final List<Project> projects;
+
+  const ProjectsPage({required this.projects, super.key});
 
   @override
   Component build(BuildContext context) {

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -3,6 +3,7 @@ import 'package:jaspr/jaspr.dart';
 import '../components/footer.dart';
 import '../components/header.dart';
 import '../constants.dart';
+import '../models/data_model.dart';
 import '../projects_content.dart';
 
 class ProjectsPage extends StatelessComponent {

--- a/lib/projects_content.dart
+++ b/lib/projects_content.dart
@@ -32,7 +32,7 @@ List<Project> _loadProjects() {
 }
 
 Project parseProjectFile(File file) {
-  final parsed = parseFrontmatterFile(file);
+  final parsed = parseFrontmatterFile(file, requireFrontmatter: true);
   final yamlMap = parsed.frontmatter;
 
   final name = yamlMap['name']?.toString();

--- a/lib/projects_content.dart
+++ b/lib/projects_content.dart
@@ -1,43 +1,8 @@
 import 'dart:io';
-import 'package:markdown/markdown.dart' as md;
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
-
-class Project {
-  final String id;
-  final String name;
-  final String repo; // e.g. kevmoo/pubviz
-  final String? pubPackage; // e.g. pubviz
-  final String? installCommand;
-  final bool featured;
-  final bool ignore;
-  final List<String> relatedPostPermalinks;
-  final String contentHtml;
-  final String? latestVersion;
-  final int? githubStars;
-  final String? pubUrl;
-  final String? githubUrl;
-  final String? lastReviewedSha;
-  final DateTime? lastReviewedAt;
-
-  Project({
-    required this.id,
-    required this.name,
-    required this.repo,
-    this.pubPackage,
-    this.installCommand,
-    this.featured = false,
-    this.ignore = false,
-    this.relatedPostPermalinks = const [],
-    required this.contentHtml,
-    this.latestVersion,
-    this.githubStars,
-    this.pubUrl,
-    this.githubUrl,
-    this.lastReviewedSha,
-    this.lastReviewedAt,
-  });
-}
+import 'models/data_model.dart';
+import 'server/content_parser.dart';
 
 List<Project> get projects => _loadProjects();
 
@@ -67,24 +32,8 @@ List<Project> _loadProjects() {
 }
 
 Project parseProjectFile(File file) {
-  final content = file.readAsStringSync();
-  if (!content.startsWith('---')) {
-    throw const FormatException(
-      'File does not start with YAML frontmatter delimiter (---)',
-    );
-  }
-
-  final parts = content.split('---');
-  if (parts.length < 3) {
-    throw const FormatException(
-      'Malformed YAML frontmatter (missing closing ---)',
-    );
-  }
-
-  final yamlMap = loadYaml(parts[1]);
-  if (yamlMap is! YamlMap) {
-    throw const FormatException('YAML frontmatter is not a key-value map');
-  }
+  final parsed = parseFrontmatterFile(file);
+  final yamlMap = parsed.frontmatter;
 
   final name = yamlMap['name']?.toString();
   final repo = yamlMap['repo']?.toString();
@@ -94,12 +43,6 @@ Project parseProjectFile(File file) {
   if (repo == null || repo.trim().isEmpty) {
     throw const FormatException('Missing required field "repo"');
   }
-
-  final bodyContent = parts.sublist(2).join('---').trim();
-  final contentHtml = md.markdownToHtml(
-    bodyContent,
-    extensionSet: md.ExtensionSet.gitHubFlavored,
-  );
 
   final id = p.basenameWithoutExtension(file.path);
   final pubPkg = yamlMap['pub_package']?.toString();
@@ -125,7 +68,7 @@ Project parseProjectFile(File file) {
             ?.map((e) => e.toString())
             .toList() ??
         const [],
-    contentHtml: contentHtml,
+    contentHtml: parsed.bodyHtml,
     latestVersion: yamlMap['version']?.toString(),
     githubStars: yamlMap['stars'] is int
         ? yamlMap['stars'] as int

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -2,31 +2,53 @@ import 'dart:io';
 import 'package:markdown/markdown.dart' as md;
 import 'package:yaml/yaml.dart';
 
-typedef ParsedContent = ({
-  YamlMap frontmatter,
-  String bodyMarkdown,
-  String bodyHtml,
-});
+class ParsedContent {
+  final YamlMap frontmatter;
+  final String bodyMarkdown;
+  final List<md.BlockSyntax> _blockSyntaxes;
+
+  ParsedContent({
+    required this.frontmatter,
+    required this.bodyMarkdown,
+    this._blockSyntaxes = const [],
+  });
+
+  late final String bodyHtml = md.markdownToHtml(
+    bodyMarkdown,
+    extensionSet: md.ExtensionSet.gitHubFlavored,
+    blockSyntaxes: _blockSyntaxes,
+  );
+}
 
 ParsedContent parseFrontmatterFile(
   File file, {
   List<md.BlockSyntax> blockSyntaxes = const [],
+  bool requireFrontmatter = false,
 }) {
   final content = file.readAsStringSync();
-  return parseFrontmatterString(content, blockSyntaxes: blockSyntaxes);
+  return parseFrontmatterString(
+    content,
+    blockSyntaxes: blockSyntaxes,
+    requireFrontmatter: requireFrontmatter,
+  );
 }
 
 ParsedContent parseFrontmatterString(
   String content, {
   List<md.BlockSyntax> blockSyntaxes = const [],
+  bool requireFrontmatter = false,
 }) {
   if (!content.startsWith('---')) {
-    final bodyHtml = md.markdownToHtml(
-      content,
-      extensionSet: md.ExtensionSet.gitHubFlavored,
+    if (requireFrontmatter) {
+      throw const FormatException(
+        'File does not start with frontmatter delimiter (---)',
+      );
+    }
+    return ParsedContent(
+      frontmatter: YamlMap(),
+      bodyMarkdown: content,
       blockSyntaxes: blockSyntaxes,
     );
-    return (frontmatter: YamlMap(), bodyMarkdown: content, bodyHtml: bodyHtml);
   }
 
   final parts = content.split('---');
@@ -42,11 +64,9 @@ ParsedContent parseFrontmatterString(
     throw const FormatException('Frontmatter is not a key-value map');
   }
 
-  final bodyHtml = md.markdownToHtml(
-    bodyMarkdown,
-    extensionSet: md.ExtensionSet.gitHubFlavored,
+  return ParsedContent(
+    frontmatter: yaml,
+    bodyMarkdown: bodyMarkdown,
     blockSyntaxes: blockSyntaxes,
   );
-
-  return (frontmatter: yaml, bodyMarkdown: bodyMarkdown, bodyHtml: bodyHtml);
 }

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -65,12 +65,17 @@ ParsedContent parseFrontmatterString(
   final bodyMarkdown = (match.group(2) ?? '').trim();
 
   final yaml = loadYaml(frontmatterString);
-  if (yaml is! YamlMap) {
+  final YamlMap yamlMap;
+  if (yaml == null) {
+    yamlMap = YamlMap.wrap(const {});
+  } else if (yaml is YamlMap) {
+    yamlMap = yaml;
+  } else {
     throw const FormatException('Frontmatter is not a key-value map');
   }
 
   return ParsedContent(
-    frontmatter: yaml,
+    frontmatter: yamlMap,
     bodyMarkdown: bodyMarkdown,
     blockSyntaxes: blockSyntaxes,
   );

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -64,7 +64,7 @@ ParsedContent parseFrontmatterString(
     }
     return ParsedContent(
       frontmatter: YamlMap.wrap(const {}),
-      bodyMarkdown: '',
+      bodyMarkdown: content,
       blockSyntaxes: blockSyntaxes,
     );
   }

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -8,19 +8,18 @@ final _frontmatterDelimiter = RegExp(r'^---[ \t]*\r?$', multiLine: true);
 class ParsedContent {
   final YamlMap frontmatter;
   final String bodyMarkdown;
-  final List<md.BlockSyntax> _blockSyntaxes;
+  final List<md.BlockSyntax> blockSyntaxes;
 
   ParsedContent({
     required this.frontmatter,
     required this.bodyMarkdown,
-    List<md.BlockSyntax> blockSyntaxes = const [],
-    // ignore: prefer_initializing_formals
-  }) : _blockSyntaxes = blockSyntaxes;
+    this.blockSyntaxes = const [],
+  });
 
   late final String bodyHtml = md.markdownToHtml(
     bodyMarkdown,
     extensionSet: md.ExtensionSet.gitHubFlavored,
-    blockSyntaxes: _blockSyntaxes,
+    blockSyntaxes: blockSyntaxes,
   );
 }
 

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'package:markdown/markdown.dart' as md;
+import 'package:yaml/yaml.dart';
+
+typedef ParsedContent = ({
+  YamlMap frontmatter,
+  String bodyMarkdown,
+  String bodyHtml,
+});
+
+ParsedContent parseFrontmatterFile(
+  File file, {
+  List<md.BlockSyntax> blockSyntaxes = const [],
+}) {
+  final content = file.readAsStringSync();
+  return parseFrontmatterString(content, blockSyntaxes: blockSyntaxes);
+}
+
+ParsedContent parseFrontmatterString(
+  String content, {
+  List<md.BlockSyntax> blockSyntaxes = const [],
+}) {
+  if (!content.startsWith('---')) {
+    final bodyHtml = md.markdownToHtml(
+      content,
+      extensionSet: md.ExtensionSet.gitHubFlavored,
+      blockSyntaxes: blockSyntaxes,
+    );
+    return (frontmatter: YamlMap(), bodyMarkdown: content, bodyHtml: bodyHtml);
+  }
+
+  final parts = content.split('---');
+  if (parts.length < 3) {
+    throw const FormatException('Malformed frontmatter (missing closing ---)');
+  }
+
+  final frontmatterString = parts[1];
+  final bodyMarkdown = parts.sublist(2).join('---').trim();
+
+  final yaml = loadYaml(frontmatterString);
+  if (yaml is! YamlMap) {
+    throw const FormatException('Frontmatter is not a key-value map');
+  }
+
+  final bodyHtml = md.markdownToHtml(
+    bodyMarkdown,
+    extensionSet: md.ExtensionSet.gitHubFlavored,
+    blockSyntaxes: blockSyntaxes,
+  );
+
+  return (frontmatter: yaml, bodyMarkdown: bodyMarkdown, bodyHtml: bodyHtml);
+}

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -71,8 +71,15 @@ ParsedContent parseFrontmatterString(
   final matches = _frontmatterDelimiter.allMatches(content, firstLineEnd + 1);
 
   if (matches.isEmpty) {
-    throw const FormatException(
-      'Malformed frontmatter (missing closing --- on its own line)',
+    if (requireFrontmatter) {
+      throw const FormatException(
+        'Malformed frontmatter (missing closing --- on its own line)',
+      );
+    }
+    return ParsedContent(
+      frontmatter: YamlMap.wrap(const {}),
+      bodyMarkdown: content,
+      blockSyntaxes: blockSyntaxes,
     );
   }
 
@@ -83,19 +90,30 @@ ParsedContent parseFrontmatterString(
   );
   final bodyMarkdown = content.substring(closingMatch.end).trim();
 
-  final yaml = loadYaml(frontmatterString);
-  final YamlMap yamlMap;
-  if (yaml == null) {
-    yamlMap = YamlMap.wrap(const {});
-  } else if (yaml is YamlMap) {
-    yamlMap = yaml;
-  } else {
-    throw const FormatException('Frontmatter is not a key-value map');
-  }
+  try {
+    final yaml = loadYaml(frontmatterString);
+    final YamlMap yamlMap;
+    if (yaml == null) {
+      yamlMap = YamlMap.wrap(const {});
+    } else if (yaml is YamlMap) {
+      yamlMap = yaml;
+    } else {
+      throw const FormatException('Frontmatter is not a key-value map');
+    }
 
-  return ParsedContent(
-    frontmatter: yamlMap,
-    bodyMarkdown: bodyMarkdown,
-    blockSyntaxes: blockSyntaxes,
-  );
+    return ParsedContent(
+      frontmatter: yamlMap,
+      bodyMarkdown: bodyMarkdown,
+      blockSyntaxes: blockSyntaxes,
+    );
+  } catch (e) {
+    if (requireFrontmatter) {
+      rethrow;
+    }
+    return ParsedContent(
+      frontmatter: YamlMap.wrap(const {}),
+      bodyMarkdown: content,
+      blockSyntaxes: blockSyntaxes,
+    );
+  }
 }

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -2,6 +2,9 @@ import 'dart:io';
 import 'package:markdown/markdown.dart' as md;
 import 'package:yaml/yaml.dart';
 
+final _frontmatterStart = RegExp(r'^---[ \t]*\r?(?:\n|$)');
+final _frontmatterDelimiter = RegExp(r'^---[ \t]*\r?$', multiLine: true);
+
 class ParsedContent {
   final YamlMap frontmatter;
   final String bodyMarkdown;
@@ -38,7 +41,7 @@ ParsedContent parseFrontmatterString(
   List<md.BlockSyntax> blockSyntaxes = const [],
   bool requireFrontmatter = false,
 }) {
-  if (!content.startsWith('---')) {
+  if (!_frontmatterStart.hasMatch(content)) {
     if (requireFrontmatter) {
       throw const FormatException(
         'File does not start with frontmatter delimiter (---)',
@@ -53,15 +56,19 @@ ParsedContent parseFrontmatterString(
 
   final firstLineEnd = content.indexOf('\n');
   if (firstLineEnd == -1) {
-    throw const FormatException(
-      'Malformed frontmatter (missing closing --- on its own line)',
+    if (requireFrontmatter) {
+      throw const FormatException(
+        'Malformed frontmatter (missing closing --- on its own line)',
+      );
+    }
+    return ParsedContent(
+      frontmatter: YamlMap.wrap(const {}),
+      bodyMarkdown: '',
+      blockSyntaxes: blockSyntaxes,
     );
   }
 
-  final matches = RegExp(
-    r'^---[ \t]*\r?$',
-    multiLine: true,
-  ).allMatches(content, firstLineEnd + 1);
+  final matches = _frontmatterDelimiter.allMatches(content, firstLineEnd + 1);
 
   if (matches.isEmpty) {
     throw const FormatException(

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -13,8 +13,9 @@ class ParsedContent {
   ParsedContent({
     required this.frontmatter,
     required this.bodyMarkdown,
-    this._blockSyntaxes = const [],
-  });
+    List<md.BlockSyntax> blockSyntaxes = const [],
+    // ignore: prefer_initializing_formals
+  }) : _blockSyntaxes = blockSyntaxes;
 
   late final String bodyHtml = md.markdownToHtml(
     bodyMarkdown,

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -51,13 +51,18 @@ ParsedContent parseFrontmatterString(
     );
   }
 
-  final parts = content.split('---');
-  if (parts.length < 3) {
-    throw const FormatException('Malformed frontmatter (missing closing ---)');
+  final frontmatterRegExp = RegExp(
+    r'^---[ \t]*[\r\n]+([\s\S]*?)[\r\n]+---[ \t]*[\r\n]*([\s\S]*)$',
+  );
+  final match = frontmatterRegExp.firstMatch(content);
+  if (match == null) {
+    throw const FormatException(
+      'Malformed frontmatter (missing closing --- on its own line)',
+    );
   }
 
-  final frontmatterString = parts[1];
-  final bodyMarkdown = parts.sublist(2).join('---').trim();
+  final frontmatterString = match.group(1) ?? '';
+  final bodyMarkdown = (match.group(2) ?? '').trim();
 
   final yaml = loadYaml(frontmatterString);
   if (yaml is! YamlMap) {

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -51,18 +51,30 @@ ParsedContent parseFrontmatterString(
     );
   }
 
-  final frontmatterRegExp = RegExp(
-    r'^---[ \t]*[\r\n]+([\s\S]*?)[\r\n]+---[ \t]*[\r\n]*([\s\S]*)$',
-  );
-  final match = frontmatterRegExp.firstMatch(content);
-  if (match == null) {
+  final firstLineEnd = content.indexOf('\n');
+  if (firstLineEnd == -1) {
     throw const FormatException(
       'Malformed frontmatter (missing closing --- on its own line)',
     );
   }
 
-  final frontmatterString = match.group(1) ?? '';
-  final bodyMarkdown = (match.group(2) ?? '').trim();
+  final matches = RegExp(
+    r'^---[ \t]*\r?$',
+    multiLine: true,
+  ).allMatches(content, firstLineEnd + 1);
+
+  if (matches.isEmpty) {
+    throw const FormatException(
+      'Malformed frontmatter (missing closing --- on its own line)',
+    );
+  }
+
+  final closingMatch = matches.first;
+  final frontmatterString = content.substring(
+    firstLineEnd + 1,
+    closingMatch.start,
+  );
+  final bodyMarkdown = content.substring(closingMatch.end).trim();
 
   final yaml = loadYaml(frontmatterString);
   final YamlMap yamlMap;

--- a/lib/server/content_parser.dart
+++ b/lib/server/content_parser.dart
@@ -45,7 +45,7 @@ ParsedContent parseFrontmatterString(
       );
     }
     return ParsedContent(
-      frontmatter: YamlMap(),
+      frontmatter: YamlMap.wrap(const {}),
       bodyMarkdown: content,
       blockSyntaxes: blockSyntaxes,
     );

--- a/test/content_parser_test.dart
+++ b/test/content_parser_test.dart
@@ -16,7 +16,7 @@ This is the body.
 ''';
       final parsed = parseFrontmatterString(content, requireFrontmatter: true);
       check(parsed.frontmatter['title'].toString()).equals('Hello World');
-      check(parsed.frontmatter['tags']).isA<List>();
+      check(parsed.frontmatter['tags']).isA<List<dynamic>>();
       check(parsed.bodyMarkdown).equals('This is the body.');
     });
 
@@ -34,22 +34,17 @@ This is the body.
       ).throws<FormatException>();
     });
 
-    test(
-      'Gracefully handle malformed closing delimiter when requireFrontmatter is false',
-      () {
-        const content = '''
+    test('Gracefully handle malformed closing delimiter when '
+        'requireFrontmatter is false', () {
+      const content = '''
 ---
 title: No closing delimiter
 This is the body that starts with horizontal rule-like delimiter
 ''';
-        final parsed = parseFrontmatterString(
-          content,
-          requireFrontmatter: false,
-        );
-        check(parsed.frontmatter).isEmpty();
-        check(parsed.bodyMarkdown).equals(content);
-      },
-    );
+      final parsed = parseFrontmatterString(content, requireFrontmatter: false);
+      check(parsed.frontmatter).isEmpty();
+      check(parsed.bodyMarkdown).equals(content);
+    });
 
     test(
       'Throw on malformed closing delimiter when requireFrontmatter is true',

--- a/test/content_parser_test.dart
+++ b/test/content_parser_test.dart
@@ -1,0 +1,92 @@
+import 'package:checks/checks.dart';
+import 'package:test/test.dart';
+import 'package:work_j832_com/server/content_parser.dart';
+
+void main() {
+  group('Content Parser Tests', () {
+    test('Parse valid frontmatter', () {
+      const content = '''
+---
+title: Hello World
+tags:
+  - dart
+  - jaspr
+---
+This is the body.
+''';
+      final parsed = parseFrontmatterString(content, requireFrontmatter: true);
+      check(parsed.frontmatter['title'].toString()).equals('Hello World');
+      check(parsed.frontmatter['tags']).isA<List>();
+      check(parsed.bodyMarkdown).equals('This is the body.');
+    });
+
+    test('Parse optional frontmatter when not present', () {
+      const content = 'This is just markdown without frontmatter.';
+      final parsed = parseFrontmatterString(content, requireFrontmatter: false);
+      check(parsed.frontmatter).isEmpty();
+      check(parsed.bodyMarkdown).equals(content);
+    });
+
+    test('Throw on missing frontmatter when requireFrontmatter is true', () {
+      const content = 'This is just markdown without frontmatter.';
+      check(
+        () => parseFrontmatterString(content, requireFrontmatter: true),
+      ).throws<FormatException>();
+    });
+
+    test(
+      'Gracefully handle malformed closing delimiter when requireFrontmatter is false',
+      () {
+        const content = '''
+---
+title: No closing delimiter
+This is the body that starts with horizontal rule-like delimiter
+''';
+        final parsed = parseFrontmatterString(
+          content,
+          requireFrontmatter: false,
+        );
+        check(parsed.frontmatter).isEmpty();
+        check(parsed.bodyMarkdown).equals(content);
+      },
+    );
+
+    test(
+      'Throw on malformed closing delimiter when requireFrontmatter is true',
+      () {
+        const content = '''
+---
+title: No closing delimiter
+This is the body.
+''';
+        check(
+          () => parseFrontmatterString(content, requireFrontmatter: true),
+        ).throws<FormatException>();
+      },
+    );
+
+    test('Gracefully handle invalid YAML when requireFrontmatter is false', () {
+      const content = '''
+---
+invalid: yaml: parsing: error: here
+---
+Body
+''';
+      final parsed = parseFrontmatterString(content, requireFrontmatter: false);
+      check(parsed.frontmatter).isEmpty();
+      check(parsed.bodyMarkdown).equals(content);
+    });
+
+    test('Throw on invalid YAML when requireFrontmatter is true', () {
+      const content = '''
+---
+invalid: yaml: parsing: error: here
+---
+Body
+''';
+      check(
+        () => parseFrontmatterString(content, requireFrontmatter: true),
+      ).throws<FormatException>();
+    });
+  });
+}

--- a/test/content_parser_test.dart
+++ b/test/content_parser_test.dart
@@ -27,6 +27,14 @@ This is the body.
       check(parsed.bodyMarkdown).equals(content);
     });
 
+    test('Parse optional frontmatter when content is just delimiters '
+        'without newline', () {
+      const content = '---';
+      final parsed = parseFrontmatterString(content, requireFrontmatter: false);
+      check(parsed.frontmatter).isEmpty();
+      check(parsed.bodyMarkdown).equals(content);
+    });
+
     test('Throw on missing frontmatter when requireFrontmatter is true', () {
       const content = 'This is just markdown without frontmatter.';
       check(

--- a/tool/clean_projects.dart
+++ b/tool/clean_projects.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+
+import 'package:work_j832_com/server/content_parser.dart';
 import 'package:yaml/yaml.dart';
 
 void main() {
@@ -15,11 +17,15 @@ void main() {
     final content = file.readAsStringSync();
     if (!content.startsWith('---')) continue;
 
-    final parts = content.split('---');
-    if (parts.length < 3) continue;
+    final ParsedContent parsed;
+    try {
+      parsed = parseFrontmatterString(content, requireFrontmatter: true);
+    } catch (_) {
+      continue;
+    }
 
-    final yamlMap = loadYaml(parts[1]) as YamlMap;
-    final bodyContent = parts.sublist(2).join('---').trim();
+    final yamlMap = parsed.frontmatter;
+    final bodyContent = parsed.bodyMarkdown;
 
     final pubPkg = yamlMap['pub_package']?.toString();
     final lines = <String>['---'];

--- a/tool/clean_projects.dart
+++ b/tool/clean_projects.dart
@@ -20,7 +20,8 @@ void main() {
     final ParsedContent parsed;
     try {
       parsed = parseFrontmatterString(content, requireFrontmatter: true);
-    } catch (_) {
+    } catch (e) {
+      print('Warning: Failed to parse frontmatter in ${file.path}: $e');
       continue;
     }
 

--- a/tool/triage_projects.dart
+++ b/tool/triage_projects.dart
@@ -32,7 +32,8 @@ void main(List<String> args) async {
     final ParsedContent parsed;
     try {
       parsed = parseFrontmatterString(content, requireFrontmatter: true);
-    } catch (_) {
+    } catch (e) {
+      print('Warning: Failed to parse frontmatter in ${file.path}: $e');
       continue;
     }
 

--- a/tool/triage_projects.dart
+++ b/tool/triage_projects.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:path/path.dart' as p;
+import 'package:work_j832_com/server/content_parser.dart';
 import 'package:yaml/yaml.dart';
 
 void main(List<String> args) async {
@@ -27,11 +29,15 @@ void main(List<String> args) async {
     final content = file.readAsStringSync();
     if (!content.startsWith('---')) continue;
 
-    final parts = content.split('---');
-    if (parts.length < 3) continue;
+    final ParsedContent parsed;
+    try {
+      parsed = parseFrontmatterString(content, requireFrontmatter: true);
+    } catch (_) {
+      continue;
+    }
 
-    final yamlMap = loadYaml(parts[1]) as YamlMap;
-    final bodyContent = parts.sublist(2).join('---').trim();
+    final yamlMap = parsed.frontmatter;
+    final bodyContent = parsed.bodyMarkdown;
 
     final name = yamlMap['name']?.toString() ?? p.basename(file.path);
     final repo = yamlMap['repo']?.toString();


### PR DESCRIPTION
- Relocated the Project class definition to lib/models/data_model.dart to resolve transitive dart:io import issues, making it client-safe.
- Centralized duplicated Jekyll-style YAML/Markdown parsing into a server-only helper lib/server/content_parser.dart.
- Refactored content.dart, projects_content.dart, and about.dart to use the new helper.
- Fixes #30
