### PR TITLE
refactor(css): abstract repetitive Tailwind utility classes

### DIFF
--- a/lib/components/interactive_post_list.dart
+++ b/lib/components/interactive_post_list.dart
@@ -135,7 +135,7 @@ class _InteractivePostListState extends State<InteractivePostList> {
       }
 
       if (isVisible) {
-        itemsToRender.add(PostCard(post: post));
+        itemsToRender.add(PostCard(post: post, key: ValueKey(post.permalink)));
       }
     }
 
@@ -153,7 +153,7 @@ class _InteractivePostListState extends State<InteractivePostList> {
             // Trigger Button
             button(
               classes: 'dropdown-trigger',
-              attributes: {'id': 'flavor-dropdown-trigger'},
+              attributes: const {'id': 'flavor-dropdown-trigger'},
               events: {
                 'click': (event) => setState(() => isMenuOpen = !isMenuOpen),
               },
@@ -175,11 +175,13 @@ class _InteractivePostListState extends State<InteractivePostList> {
               div(classes: 'dropdown-menu', [
                 for (final f in availableFlavors)
                   _DropdownItem(
+                    key: ValueKey(f.name),
                     label: f.label,
                     isSelected: selectedFlavor == f,
                     onClick: () => _onFlavorSelected(f.name),
                   ),
                 _DropdownItem(
+                  key: const ValueKey('everything'),
                   label: 'Everything',
                   isSelected: selectedFlavor == null,
                   onClick: () => _onFlavorSelected(''),
@@ -201,7 +203,7 @@ class _InteractivePostListState extends State<InteractivePostList> {
       if (hasMore)
         div(classes: 'text-center mt-12', [
           button(
-            attributes: {'id': 'show-more-btn'},
+            attributes: const {'id': 'show-more-btn'},
             classes: 'show-more-btn',
             events: {'click': (event) => setState(() => visibleCount += 10)},
             [const Component.text('Show more posts...')],
@@ -262,6 +264,7 @@ class _DropdownItem extends StatelessComponent {
     required this.label,
     required this.isSelected,
     required this.onClick,
+    super.key,
   });
 
   @override

--- a/lib/components/interactive_post_list.dart
+++ b/lib/components/interactive_post_list.dart
@@ -120,6 +120,7 @@ class _InteractivePostListState extends State<InteractivePostList> {
           final topPadding = isFirst ? 'pt-0' : 'pt-10';
           itemsToRender.add(
             div(
+              key: ValueKey('year-$postYear'),
               classes:
                   'year-marker year-marker-container $topPadding first:pt-0',
               attributes: {'data-year': '$postYear'},

--- a/lib/components/interactive_post_list.dart
+++ b/lib/components/interactive_post_list.dart
@@ -174,12 +174,12 @@ class _InteractivePostListState extends State<InteractivePostList> {
             if (isMenuOpen)
               div(classes: 'dropdown-menu', [
                 for (final f in availableFlavors)
-                  _buildDropdownItem(
+                  _DropdownItem(
                     label: f.label,
                     isSelected: selectedFlavor == f,
                     onClick: () => _onFlavorSelected(f.name),
                   ),
-                _buildDropdownItem(
+                _DropdownItem(
                   label: 'Everything',
                   isSelected: selectedFlavor == null,
                   onClick: () => _onFlavorSelected(''),
@@ -209,31 +209,6 @@ class _InteractivePostListState extends State<InteractivePostList> {
         ]),
     ]);
   }
-
-  Component _buildDropdownItem({
-    required String label,
-    required bool isSelected,
-    required VoidCallback onClick,
-  }) {
-    final stateClass = isSelected
-        ? 'dropdown-item-active'
-        : 'dropdown-item-inactive';
-
-    return button(
-      classes: 'dropdown-item-base $stateClass',
-      events: {'click': (event) => onClick()},
-      [
-        Component.text(label),
-        if (isSelected)
-          const Component.element(
-            tag: 'i',
-            classes:
-                'fas fa-check text-blue-600 dark:text-blue-400 text-xs ml-2',
-            children: [],
-          ),
-      ],
-    );
-  }
 }
 
 class PostCard extends StatelessComponent {
@@ -255,7 +230,7 @@ class PostCard extends StatelessComponent {
           a(
             href: post.linkUrl,
             target: post.isWriting ? null : Target.blank,
-            attributes: post.isWriting ? {} : {'rel': 'noopener'},
+            attributes: post.isWriting ? const {} : const {'rel': 'noopener'},
             classes: 'card-title-link',
             [
               Component.text(post.title.trim()),
@@ -274,6 +249,35 @@ class PostCard extends StatelessComponent {
           div(classes: 'card-subtitle', [Component.text(post.subTitle)]),
       ]),
       div(classes: 'card-date', [Component.text(post.dateString)]),
+    ],
+  );
+}
+
+class _DropdownItem extends StatelessComponent {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onClick;
+
+  const _DropdownItem({
+    required this.label,
+    required this.isSelected,
+    required this.onClick,
+  });
+
+  @override
+  Component build(BuildContext context) => button(
+    classes:
+        'dropdown-item-base '
+        '${isSelected ? 'dropdown-item-active' : 'dropdown-item-inactive'}',
+    events: {'click': (event) => onClick()},
+    [
+      Component.text(label),
+      if (isSelected)
+        const Component.element(
+          tag: 'i',
+          classes: 'fas fa-check text-blue-600 dark:text-blue-400 text-xs ml-2',
+          children: [],
+        ),
     ],
   );
 }

--- a/lib/components/interactive_post_list.dart
+++ b/lib/components/interactive_post_list.dart
@@ -154,7 +154,10 @@ class _InteractivePostListState extends State<InteractivePostList> {
             // Trigger Button
             button(
               classes: 'dropdown-trigger',
-              attributes: const {'id': 'flavor-dropdown-trigger'},
+              attributes: const {
+                'id': 'flavor-dropdown-trigger',
+                'type': 'button',
+              },
               events: {
                 'click': (event) => setState(() => isMenuOpen = !isMenuOpen),
               },
@@ -204,7 +207,7 @@ class _InteractivePostListState extends State<InteractivePostList> {
       if (hasMore)
         div(classes: 'text-center mt-12', [
           button(
-            attributes: const {'id': 'show-more-btn'},
+            attributes: const {'id': 'show-more-btn', 'type': 'button'},
             classes: 'show-more-btn',
             events: {'click': (event) => setState(() => visibleCount += 10)},
             [const Component.text('Show more posts...')],
@@ -273,6 +276,7 @@ class _DropdownItem extends StatelessComponent {
     classes:
         'dropdown-item-base '
         '${isSelected ? 'dropdown-item-active' : 'dropdown-item-inactive'}',
+    attributes: const {'type': 'button'},
     events: {'click': (event) => onClick()},
     [
       Component.text(label),

--- a/lib/components/interactive_post_list.dart
+++ b/lib/components/interactive_post_list.dart
@@ -121,20 +121,13 @@ class _InteractivePostListState extends State<InteractivePostList> {
           itemsToRender.add(
             div(
               classes:
-                  'year-marker flex items-center gap-4 $topPadding '
-                  'first:pt-0 pb-4',
+                  'year-marker year-marker-container $topPadding first:pt-0',
               attributes: {'data-year': '$postYear'},
               [
-                span(
-                  classes: 'text-sky-400/90 font-black tracking-widest text-lg',
-                  [Component.text('$postYear')],
-                ),
-                const div(
-                  classes:
-                      'flex-grow h-[1px] bg-gradient-to-r '
-                      'from-sky-500/30 via-sky-500/10 to-transparent',
-                  [],
-                ),
+                span(classes: 'year-marker-text', [
+                  Component.text('$postYear'),
+                ]),
+                const div(classes: 'year-marker-line', []),
               ],
             ),
           );
@@ -142,7 +135,7 @@ class _InteractivePostListState extends State<InteractivePostList> {
       }
 
       if (isVisible) {
-        itemsToRender.add(_buildPostCard(post));
+        itemsToRender.add(PostCard(post: post));
       }
     }
 
@@ -159,12 +152,7 @@ class _InteractivePostListState extends State<InteractivePostList> {
           div(classes: 'relative inline-block text-left', [
             // Trigger Button
             button(
-              classes:
-                  'bg-slate-100 dark:bg-slate-900 border border-slate-200 '
-                  'dark:border-slate-800 text-slate-700 dark:text-slate-300 '
-                  'text-sm font-semibold rounded-xl hover:bg-slate-200/80 '
-                  'dark:hover:bg-slate-800 transition-all shadow-sm '
-                  'cursor-pointer py-2.5 px-4 flex items-center gap-2',
+              classes: 'dropdown-trigger',
               attributes: {'id': 'flavor-dropdown-trigger'},
               events: {
                 'click': (event) => setState(() => isMenuOpen = !isMenuOpen),
@@ -184,26 +172,19 @@ class _InteractivePostListState extends State<InteractivePostList> {
 
             // Floating Menu Popup
             if (isMenuOpen)
-              div(
-                classes:
-                    'absolute right-0 mt-2 w-56 rounded-xl bg-white '
-                    'dark:bg-slate-900 border border-slate-200 '
-                    'dark:border-slate-800 shadow-xl p-1.5 z-50 '
-                    'flex flex-col gap-0.5 text-left',
-                [
-                  for (final f in availableFlavors)
-                    _buildDropdownItem(
-                      label: f.label,
-                      isSelected: selectedFlavor == f,
-                      onClick: () => _onFlavorSelected(f.name),
-                    ),
+              div(classes: 'dropdown-menu', [
+                for (final f in availableFlavors)
                   _buildDropdownItem(
-                    label: 'Everything',
-                    isSelected: selectedFlavor == null,
-                    onClick: () => _onFlavorSelected(''),
+                    label: f.label,
+                    isSelected: selectedFlavor == f,
+                    onClick: () => _onFlavorSelected(f.name),
                   ),
-                ],
-              ),
+                _buildDropdownItem(
+                  label: 'Everything',
+                  isSelected: selectedFlavor == null,
+                  onClick: () => _onFlavorSelected(''),
+                ),
+              ]),
           ]),
         ],
       ),
@@ -221,13 +202,7 @@ class _InteractivePostListState extends State<InteractivePostList> {
         div(classes: 'text-center mt-12', [
           button(
             attributes: {'id': 'show-more-btn'},
-            classes:
-                'bg-slate-100 dark:bg-slate-900 border '
-                'border-slate-200 dark:border-slate-800 text-slate-700 '
-                'dark:text-slate-300 px-6 py-2.5 rounded-lg text-sm '
-                'font-semibold hover:bg-slate-200/80 '
-                'dark:hover:bg-slate-800 transition-all shadow-sm '
-                'cursor-pointer',
+            classes: 'show-more-btn',
             events: {'click': (event) => setState(() => visibleCount += 10)},
             [const Component.text('Show more posts...')],
           ),
@@ -235,82 +210,17 @@ class _InteractivePostListState extends State<InteractivePostList> {
     ]);
   }
 
-  Component _buildPostCard(ClientPostItem post) => div(
-    classes:
-        'border border-slate-200 dark:border-slate-800/80 rounded-xl '
-        'p-5 bg-slate-50/50 dark:bg-slate-900/50 shadow-sm '
-        'hover:border-blue-500/40 dark:hover:border-blue-400/50 '
-        'transition-all appearance-card flex items-center gap-4',
-    attributes: {
-      'data-tags': post.tags.join(','),
-      'data-year': post.year.toString(),
-    },
-    [
-      div(
-        classes:
-            'icon text-blue-600 dark:text-blue-400 w-10 text-center '
-            'flex-shrink-0',
-        [RawText(post.awesomeHtml)],
-      ),
-      div(classes: 'details flex flex-col text-left flex-1', [
-        div(
-          classes:
-              'title text-base font-bold text-slate-900 dark:text-white '
-              'mb-0.5',
-          [
-            a(
-              href: post.linkUrl,
-              target: post.isWriting ? null : Target.blank,
-              attributes: post.isWriting ? {} : {'rel': 'noopener'},
-              classes:
-                  'hover:text-blue-600 dark:hover:text-blue-400 '
-                  'transition-colors',
-              [
-                Component.text(post.title.trim()),
-                if (!post.isWriting) ...[
-                  const RawText('&nbsp;'),
-                  const Component.element(
-                    tag: 'i',
-                    classes: 'fa fa-external-link-alt text-xs opacity-50',
-                    children: [],
-                  ),
-                ],
-              ],
-            ),
-          ],
-        ),
-        if (post.subTitle.isNotEmpty)
-          div(classes: 'subtitle text-xs text-slate-500 dark:text-slate-400', [
-            Component.text(post.subTitle),
-          ]),
-      ]),
-      div(
-        classes:
-            'date font-mono text-xs text-slate-400 dark:text-slate-500 '
-            'whitespace-nowrap ml-2',
-        [Component.text(post.dateString)],
-      ),
-    ],
-  );
-
   Component _buildDropdownItem({
     required String label,
     required bool isSelected,
     required VoidCallback onClick,
   }) {
-    final activeClasses =
-        'bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 '
-        'font-bold';
-    final inactiveClasses =
-        'text-slate-700 dark:text-slate-300 hover:bg-slate-100 '
-        'dark:hover:bg-slate-800/80';
-    final stateClasses = isSelected ? activeClasses : inactiveClasses;
+    final stateClass = isSelected
+        ? 'dropdown-item-active'
+        : 'dropdown-item-inactive';
 
     return button(
-      classes:
-          'w-full px-4 py-2.5 rounded-lg text-left text-sm font-medium '
-          'transition-colors cursor-pointer flex items-center '
-          'justify-between $stateClasses',
+      classes: 'dropdown-item-base $stateClass',
       events: {'click': (event) => onClick()},
       [
         Component.text(label),
@@ -324,4 +234,46 @@ class _InteractivePostListState extends State<InteractivePostList> {
       ],
     );
   }
+}
+
+class PostCard extends StatelessComponent {
+  final ClientPostItem post;
+
+  const PostCard({required this.post, super.key});
+
+  @override
+  Component build(BuildContext context) => div(
+    classes: 'appearance-card',
+    attributes: {
+      'data-tags': post.tags.join(','),
+      'data-year': post.year.toString(),
+    },
+    [
+      div(classes: 'card-icon', [RawText(post.awesomeHtml)]),
+      div(classes: 'card-details', [
+        div(classes: 'card-title', [
+          a(
+            href: post.linkUrl,
+            target: post.isWriting ? null : Target.blank,
+            attributes: post.isWriting ? {} : {'rel': 'noopener'},
+            classes: 'card-title-link',
+            [
+              Component.text(post.title.trim()),
+              if (!post.isWriting) ...[
+                const RawText('&nbsp;'),
+                const Component.element(
+                  tag: 'i',
+                  classes: 'fa fa-external-link-alt text-xs opacity-50',
+                  children: [],
+                ),
+              ],
+            ],
+          ),
+        ]),
+        if (post.subTitle.isNotEmpty)
+          div(classes: 'card-subtitle', [Component.text(post.subTitle)]),
+      ]),
+      div(classes: 'card-date', [Component.text(post.dateString)]),
+    ],
+  );
 }

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -109,19 +109,20 @@ class ProjectCard extends StatelessComponent {
               ),
             ],
           ),
-        a(
-          href: project.githubUrl!,
-          target: Target.blank,
-          classes: 'hover:underline flex items-center gap-1',
-          [
-            const Component.text('GitHub'),
-            const Component.element(
-              tag: 'i',
-              classes: 'fab fa-github text-sm',
-              children: [],
-            ),
-          ],
-        ),
+        if (project.githubUrl != null)
+          a(
+            href: project.githubUrl!,
+            target: Target.blank,
+            classes: 'hover:underline flex items-center gap-1',
+            [
+              const Component.text('GitHub'),
+              const Component.element(
+                tag: 'i',
+                classes: 'fab fa-github text-sm',
+                children: [],
+              ),
+            ],
+          ),
       ]),
     ]),
   ]);

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -99,6 +99,7 @@ class ProjectCard extends StatelessComponent {
           a(
             href: project.pubUrl!,
             target: Target.blank,
+            attributes: const {'rel': 'noopener'},
             classes: 'hover:underline flex items-center gap-1',
             [
               const Component.text('pub.dev'),
@@ -113,6 +114,7 @@ class ProjectCard extends StatelessComponent {
           a(
             href: project.githubUrl!,
             target: Target.blank,
+            attributes: const {'rel': 'noopener'},
             classes: 'hover:underline flex items-center gap-1',
             [
               const Component.text('GitHub'),

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -58,74 +58,78 @@ class ProjectCard extends StatelessComponent {
   const ProjectCard({required this.project, super.key});
 
   @override
-  Component build(BuildContext context) => div(classes: 'project-card', [
-    div([
-      div(classes: 'flex items-center justify-between gap-3 mb-2', [
-        div(classes: 'project-metadata', [
-          if (project.latestVersion != null)
-            span(classes: 'project-version', [
-              const Component.element(
-                tag: 'i',
-                classes: 'fas fa-tag text-[10px]',
-                children: [],
-              ),
-              Component.text('v${project.latestVersion}'),
-            ]),
-          if (project.githubStars != null)
-            span(classes: 'flex items-center gap-1', [
-              const Component.element(
-                tag: 'i',
-                classes: 'fas fa-star text-amber-400',
-                children: [],
-              ),
-              Component.text('${project.githubStars}'),
-            ]),
+  Component build(BuildContext context) {
+    final installCommand = project.installCommand;
+    final pubUrl = project.pubUrl;
+    final githubUrl = project.githubUrl;
+
+    return div(classes: 'project-card', [
+      div([
+        div(classes: 'flex items-center justify-between gap-3 mb-2', [
+          div(classes: 'project-metadata', [
+            if (project.latestVersion != null)
+              span(classes: 'project-version', [
+                const Component.element(
+                  tag: 'i',
+                  classes: 'fas fa-tag text-[10px]',
+                  children: [],
+                ),
+                Component.text('v${project.latestVersion}'),
+              ]),
+            if (project.githubStars != null)
+              span(classes: 'flex items-center gap-1', [
+                const Component.element(
+                  tag: 'i',
+                  classes: 'fas fa-star text-amber-400',
+                  children: [],
+                ),
+                Component.text('${project.githubStars}'),
+              ]),
+          ]),
+        ]),
+        h2(classes: 'project-title', [Component.text(project.name)]),
+        div(classes: 'prose prose-slate dark:prose-invert project-desc', [
+          RawText(project.contentHtml),
         ]),
       ]),
-      h2(classes: 'project-title', [Component.text(project.name)]),
-      div(classes: 'prose prose-slate dark:prose-invert project-desc', [
-        RawText(project.contentHtml),
+      div(classes: 'project-footer', [
+        if (installCommand != null && installCommand.isNotEmpty)
+          code(classes: 'project-install-cmd', [
+            Component.text(installCommand),
+          ]),
+        div(classes: 'project-links', [
+          if (pubUrl != null)
+            a(
+              href: pubUrl,
+              target: Target.blank,
+              attributes: const {'rel': 'noopener'},
+              classes: 'hover:underline flex items-center gap-1',
+              [
+                const Component.text('pub.dev'),
+                const Component.element(
+                  tag: 'i',
+                  classes: 'fas fa-external-link-alt text-[10px]',
+                  children: [],
+                ),
+              ],
+            ),
+          if (githubUrl != null)
+            a(
+              href: githubUrl,
+              target: Target.blank,
+              attributes: const {'rel': 'noopener'},
+              classes: 'hover:underline flex items-center gap-1',
+              [
+                const Component.text('GitHub'),
+                const Component.element(
+                  tag: 'i',
+                  classes: 'fab fa-github text-sm',
+                  children: [],
+                ),
+              ],
+            ),
+        ]),
       ]),
-    ]),
-    div(classes: 'project-footer', [
-      if (project.installCommand != null && project.installCommand!.isNotEmpty)
-        code(classes: 'project-install-cmd', [
-          Component.text(project.installCommand!),
-        ])
-      else
-        const span([]),
-      div(classes: 'project-links', [
-        if (project.pubUrl != null)
-          a(
-            href: project.pubUrl!,
-            target: Target.blank,
-            attributes: const {'rel': 'noopener'},
-            classes: 'hover:underline flex items-center gap-1',
-            [
-              const Component.text('pub.dev'),
-              const Component.element(
-                tag: 'i',
-                classes: 'fas fa-external-link-alt text-[10px]',
-                children: [],
-              ),
-            ],
-          ),
-        if (project.githubUrl != null)
-          a(
-            href: project.githubUrl!,
-            target: Target.blank,
-            attributes: const {'rel': 'noopener'},
-            classes: 'hover:underline flex items-center gap-1',
-            [
-              const Component.text('GitHub'),
-              const Component.element(
-                tag: 'i',
-                classes: 'fab fa-github text-sm',
-                children: [],
-              ),
-            ],
-          ),
-      ]),
-    ]),
-  ]);
+    ]);
+  }
 }

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -42,7 +42,8 @@ class ProjectsPage extends StatelessComponent {
             ),
 
             div(classes: 'grid grid-cols-1 gap-8', [
-              for (final project in allProjects) ProjectCard(project: project),
+              for (final project in allProjects)
+                ProjectCard(project: project, key: ValueKey(project.id)),
             ]),
           ]),
           const Footer(),

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -42,7 +42,7 @@ class ProjectsPage extends StatelessComponent {
             ),
 
             div(classes: 'grid grid-cols-1 gap-8', [
-              for (final project in allProjects) _buildProjectCard(project),
+              for (final project in allProjects) ProjectCard(project: project),
             ]),
           ]),
           const Footer(),
@@ -50,107 +50,79 @@ class ProjectsPage extends StatelessComponent {
       ),
     ]);
   }
+}
 
-  Component _buildProjectCard(Project project) => div(
-    classes:
-        'border border-slate-200 dark:border-slate-800/80 rounded-xl p-6 '
-        'hover:border-blue-500/40 dark:hover:border-blue-400/50 transition-all '
-        'shadow-sm bg-slate-50/50 dark:bg-slate-900/50 flex flex-col justify-between',
-    [
-      div([
-        div(classes: 'flex items-center justify-between gap-3 mb-2', [
-          div(
-            classes:
-                'flex items-center gap-3 text-xs font-medium '
-                'text-slate-500 dark:text-slate-400 ml-auto',
-            [
-              if (project.latestVersion != null)
-                span(
-                  classes:
-                      'flex items-center gap-1 bg-slate-200/60 dark:bg-slate-800 '
-                      'px-2 py-0.5 rounded text-slate-700 dark:text-slate-300',
-                  [
-                    const Component.element(
-                      tag: 'i',
-                      classes: 'fas fa-tag text-[10px]',
-                      children: [],
-                    ),
-                    Component.text('v${project.latestVersion}'),
-                  ],
-                ),
-              if (project.githubStars != null)
-                span(classes: 'flex items-center gap-1', [
-                  const Component.element(
-                    tag: 'i',
-                    classes: 'fas fa-star text-amber-400',
-                    children: [],
-                  ),
-                  Component.text('${project.githubStars}'),
-                ]),
-            ],
-          ),
+class ProjectCard extends StatelessComponent {
+  final Project project;
+
+  const ProjectCard({required this.project, super.key});
+
+  @override
+  Component build(BuildContext context) => div(classes: 'project-card', [
+    div([
+      div(classes: 'flex items-center justify-between gap-3 mb-2', [
+        div(classes: 'project-metadata', [
+          if (project.latestVersion != null)
+            span(classes: 'project-version', [
+              const Component.element(
+                tag: 'i',
+                classes: 'fas fa-tag text-[10px]',
+                children: [],
+              ),
+              Component.text('v${project.latestVersion}'),
+            ]),
+          if (project.githubStars != null)
+            span(classes: 'flex items-center gap-1', [
+              const Component.element(
+                tag: 'i',
+                classes: 'fas fa-star text-amber-400',
+                children: [],
+              ),
+              Component.text('${project.githubStars}'),
+            ]),
         ]),
-        h2(classes: 'text-2xl font-bold text-slate-900 dark:text-white mb-3', [
-          Component.text(project.name),
-        ]),
-        div(
-          classes:
-              'prose prose-slate dark:prose-invert max-w-none text-sm '
-              'text-slate-600 dark:text-slate-300 mb-6 leading-relaxed',
-          [RawText(project.contentHtml)],
-        ),
       ]),
-      div(
-        classes:
-            'flex items-center justify-between pt-4 border-t '
-            'border-slate-200/60 dark:border-slate-800/80 text-xs font-mono',
-        [
-          if (project.installCommand != null &&
-              project.installCommand!.isNotEmpty)
-            code(
-              classes:
-                  'bg-slate-200/50 dark:bg-slate-800/80 text-slate-700 '
-                  'dark:text-slate-200 px-2.5 py-1 rounded select-all',
-              [Component.text(project.installCommand!)],
-            )
-          else
-            const span([]),
-          div(
-            classes:
-                'flex items-center gap-4 font-sans font-semibold '
-                'text-blue-600 dark:text-blue-400',
+      h2(classes: 'project-title', [Component.text(project.name)]),
+      div(classes: 'prose prose-slate dark:prose-invert project-desc', [
+        RawText(project.contentHtml),
+      ]),
+    ]),
+    div(classes: 'project-footer', [
+      if (project.installCommand != null && project.installCommand!.isNotEmpty)
+        code(classes: 'project-install-cmd', [
+          Component.text(project.installCommand!),
+        ])
+      else
+        const span([]),
+      div(classes: 'project-links', [
+        if (project.pubUrl != null)
+          a(
+            href: project.pubUrl!,
+            target: Target.blank,
+            classes: 'hover:underline flex items-center gap-1',
             [
-              if (project.pubUrl != null)
-                a(
-                  href: project.pubUrl!,
-                  target: Target.blank,
-                  classes: 'hover:underline flex items-center gap-1',
-                  [
-                    const Component.text('pub.dev'),
-                    const Component.element(
-                      tag: 'i',
-                      classes: 'fas fa-external-link-alt text-[10px]',
-                      children: [],
-                    ),
-                  ],
-                ),
-              a(
-                href: project.githubUrl!,
-                target: Target.blank,
-                classes: 'hover:underline flex items-center gap-1',
-                [
-                  const Component.text('GitHub'),
-                  const Component.element(
-                    tag: 'i',
-                    classes: 'fab fa-github text-sm',
-                    children: [],
-                  ),
-                ],
+              const Component.text('pub.dev'),
+              const Component.element(
+                tag: 'i',
+                classes: 'fas fa-external-link-alt text-[10px]',
+                children: [],
               ),
             ],
           ),
-        ],
-      ),
-    ],
-  );
+        a(
+          href: project.githubUrl!,
+          target: Target.blank,
+          classes: 'hover:underline flex items-center gap-1',
+          [
+            const Component.text('GitHub'),
+            const Component.element(
+              tag: 'i',
+              classes: 'fab fa-github text-sm',
+              children: [],
+            ),
+          ],
+        ),
+      ]),
+    ]),
+  ]);
 }

--- a/styles.tw.css
+++ b/styles.tw.css
@@ -549,7 +549,7 @@
 }
 
 @utility project-links {
-  @apply flex items-center gap-4 font-sans font-semibold text-blue-600 dark:text-blue-400;
+  @apply flex items-center gap-4 font-sans font-semibold text-blue-600 dark:text-blue-400 ml-auto;
 }
 
 @utility year-marker-container {

--- a/styles.tw.css
+++ b/styles.tw.css
@@ -491,3 +491,101 @@
   }
 }
 
+/* Component utilities for reducing compiled HTML bloat */
+@utility appearance-card {
+  @apply border border-slate-200 dark:border-slate-800/80 rounded-xl p-5 bg-slate-50/50 dark:bg-slate-900/50 shadow-sm hover:border-blue-500/40 dark:hover:border-blue-400/50 transition-all flex items-center gap-4;
+}
+
+@utility card-icon {
+  @apply text-blue-600 dark:text-blue-400 w-10 text-center flex-shrink-0;
+}
+
+@utility card-details {
+  @apply flex flex-col text-left flex-1;
+}
+
+@utility card-title {
+  @apply text-base font-bold text-slate-900 dark:text-white mb-0.5;
+}
+
+@utility card-title-link {
+  @apply hover:text-blue-600 dark:hover:text-blue-400 transition-colors;
+}
+
+@utility card-subtitle {
+  @apply text-xs text-slate-500 dark:text-slate-400;
+}
+
+@utility card-date {
+  @apply font-mono text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap ml-2;
+}
+
+@utility project-card {
+  @apply border border-slate-200 dark:border-slate-800/80 rounded-xl p-6 hover:border-blue-500/40 dark:hover:border-blue-400/50 transition-all shadow-sm bg-slate-50/50 dark:bg-slate-900/50 flex flex-col justify-between;
+}
+
+@utility project-metadata {
+  @apply flex items-center gap-3 text-xs font-medium text-slate-500 dark:text-slate-400 ml-auto;
+}
+
+@utility project-version {
+  @apply flex items-center gap-1 bg-slate-200/60 dark:bg-slate-800 px-2 py-0.5 rounded text-slate-700 dark:text-slate-300;
+}
+
+@utility project-title {
+  @apply text-2xl font-bold text-slate-900 dark:text-white mb-3;
+}
+
+@utility project-desc {
+  @apply max-w-none text-sm text-slate-600 dark:text-slate-300 mb-6 leading-relaxed;
+}
+
+@utility project-footer {
+  @apply flex items-center justify-between pt-4 border-t border-slate-200/60 dark:border-slate-800/80 text-xs font-mono;
+}
+
+@utility project-install-cmd {
+  @apply bg-slate-200/50 dark:bg-slate-800/80 text-slate-700 dark:text-slate-200 px-2.5 py-1 rounded select-all;
+}
+
+@utility project-links {
+  @apply flex items-center gap-4 font-sans font-semibold text-blue-600 dark:text-blue-400;
+}
+
+@utility year-marker-container {
+  @apply flex items-center gap-4 pb-4;
+}
+
+@utility year-marker-text {
+  @apply text-sky-400/90 font-black tracking-widest text-lg;
+}
+
+@utility year-marker-line {
+  @apply flex-grow h-[1px] bg-gradient-to-r from-sky-500/30 via-sky-500/10 to-transparent;
+}
+
+@utility dropdown-trigger {
+  @apply bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 text-slate-700 dark:text-slate-300 text-sm font-semibold rounded-xl hover:bg-slate-200/80 dark:hover:bg-slate-800 transition-all shadow-sm cursor-pointer py-2.5 px-4 flex items-center gap-2;
+}
+
+@utility dropdown-menu {
+  @apply absolute right-0 mt-2 w-56 rounded-xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-xl p-1.5 z-50 flex flex-col gap-0.5 text-left;
+}
+
+@utility dropdown-item-base {
+  @apply w-full px-4 py-2.5 rounded-lg text-left text-sm font-medium transition-colors cursor-pointer flex items-center justify-between;
+}
+
+@utility dropdown-item-active {
+  @apply bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 font-bold;
+}
+
+@utility dropdown-item-inactive {
+  @apply text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800/80;
+}
+
+@utility show-more-btn {
+  @apply bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 text-slate-700 dark:text-slate-300 px-6 py-2.5 rounded-lg text-sm font-semibold hover:bg-slate-200/80 dark:hover:bg-slate-800 transition-all shadow-sm cursor-pointer;
+}
+
+


### PR DESCRIPTION
Reduce compiled HTML bloat by abstracting highly repetitive Tailwind classes into custom Tailwind v4 components/utilities.

- Extract PostCard and ProjectCard into dedicated StatelessComponent classes.
- Define custom @utility classes in styles.tw.css for cards, timeline years, and dropdown menus.
- Keep Dart templates clean, DRY, and well-structured.

Fixes #28
