### PR TITLE
feat(projects): support linking blog posts to projects

### DIFF
--- a/_posts/2015-10-19-git-alias.md
+++ b/_posts/2015-10-19-git-alias.md
@@ -3,7 +3,6 @@ layout: post
 title: Git aliases are awesome, even locally
 tags:
 - git
-project: personal_dotfiles
 ---
 
 ![git](/assets/2015-10-19-git-logo.png){: width='450' height='188' itemprop='image' }

--- a/_posts/2015-10-19-git-alias.md
+++ b/_posts/2015-10-19-git-alias.md
@@ -3,6 +3,7 @@ layout: post
 title: Git aliases are awesome, even locally
 tags:
 - git
+project: personal_dotfiles
 ---
 
 ![git](/assets/2015-10-19-git-logo.png){: width='450' height='188' itemprop='image' }

--- a/_projects/kevmoo.com.md
+++ b/_projects/kevmoo.com.md
@@ -4,8 +4,8 @@ repo: kevmoo/kevmoo.com
 featured: true
 ignore: true
 stars: 0
-last_reviewed_sha: "7b05cf2e0fc333e86dd3ba07fbbe268664a285a2"
-last_reviewed_at: "2026-07-12T06:05:50.652779Z"
+last_reviewed_sha: "3e98ada53cd2e69ed7dc754c34560d99f818ac2d"
+last_reviewed_at: "2026-07-13T06:00:29.292665Z"
 ---
 
 The source code and static engine behind this very blog and project showcase!

--- a/_projects/kevmoo_skills.md
+++ b/_projects/kevmoo_skills.md
@@ -1,0 +1,10 @@
+---
+name: kevmoo_skills
+repo: kevmoo/kevmoo_skills
+ignore: true
+stars: 4
+last_reviewed_sha: "9923d7a1f3409225e4dc90e12221a708afa213ee"
+last_reviewed_at: "2026-07-13T06:00:28.384702Z"
+---
+
+My personal repository for specialized **Agent Skills**. These skills provide procedural, actionable instructions to AI assistants for specific domains or tasks.

--- a/_projects/personal_dotfiles.md
+++ b/_projects/personal_dotfiles.md
@@ -1,6 +1,7 @@
 ---
 name: personal_dotfiles
 repo: kevmoo/personal_dotfiles
+ignore: true
 stars: 1
 last_reviewed_sha: "e6eb95899950dd1511b5d58d8feac1f8587138db"
 last_reviewed_at: "2026-07-13T06:00:23.869815Z"

--- a/_projects/personal_dotfiles.md
+++ b/_projects/personal_dotfiles.md
@@ -3,8 +3,8 @@ name: personal_dotfiles
 repo: kevmoo/personal_dotfiles
 ignore: true
 stars: 1
-last_reviewed_sha: "07cf76ae0c7c9b21305e6e365d7eb212a6d52ea6"
-last_reviewed_at: "2026-07-12T06:05:47.579120Z"
+last_reviewed_sha: "e6eb95899950dd1511b5d58d8feac1f8587138db"
+last_reviewed_at: "2026-07-13T06:00:23.869815Z"
 ---
 
 Personal macOS developer environment setup, zsh configurations, `mise` toolchains, and automation scripts (`ujust`).

--- a/_projects/personal_dotfiles.md
+++ b/_projects/personal_dotfiles.md
@@ -1,7 +1,6 @@
 ---
 name: personal_dotfiles
 repo: kevmoo/personal_dotfiles
-ignore: true
 stars: 1
 last_reviewed_sha: "e6eb95899950dd1511b5d58d8feac1f8587138db"
 last_reviewed_at: "2026-07-13T06:00:23.869815Z"

--- a/_projects/pubviz.md
+++ b/_projects/pubviz.md
@@ -8,7 +8,7 @@ ignore: true
 version: 6.1.0
 stars: 182
 last_reviewed_sha: "2e92cd53bc46d6373fafdac31f94044a2366b2f5"
-last_reviewed_at: "2026-07-12T06:05:49.976994Z"
+last_reviewed_at: "2026-07-13T06:00:27.224965Z"
 ---
 
 Visualize Dart and Flutter package dependencies as interactive HTML graphs directly from your terminal.

--- a/_projects/qr.md
+++ b/_projects/qr.md
@@ -4,9 +4,9 @@ repo: kevmoo/qr.dart
 pub_package: qr
 ignore: true
 version: 4.0.0
-stars: 401
+stars: 402
 last_reviewed_sha: "e0dd9639585fc7ba1f94bd125407388f1df3187c"
-last_reviewed_at: "2026-07-12T06:05:49.201673Z"
+last_reviewed_at: "2026-07-13T06:00:25.894699Z"
 ---
 
 Pure Dart QR code generation library supporting custom modules, error correction levels (L, M, Q, H), and flexible rendering pipelines.

--- a/_projects/slide_puzzle.md
+++ b/_projects/slide_puzzle.md
@@ -4,7 +4,7 @@ repo: kevmoo/slide_puzzle
 featured: true
 stars: 179
 last_reviewed_sha: "c467500420f38fb75b6f9aaca30e2a2b5276a677"
-last_reviewed_at: "2026-07-12T06:05:48.296926Z"
+last_reviewed_at: "2026-07-13T06:00:24.770515Z"
 ---
 
 High-performance 15-puzzle $A^*$ solver and interactive web game built with **Dart 3** and **Flutter**.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -52,7 +52,8 @@ class App extends StatelessComponent {
           Route(
             path: '/projects',
             title: 'Projects | $authorName',
-            builder: (context, state) => ProjectsPage(projects: projects),
+            builder: (context, state) =>
+                ProjectsPage(projects: projects, posts: posts),
           ),
           Route(
             path: '/feed.xml',

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -5,3 +5,36 @@ const String siteSubtitle =
 const String authorName = 'Kevin Moore';
 const String homePageTitle =
     '$authorName | Google Product Manager | Flutter & Dart';
+
+String formatReadableDate(DateTime date, {bool shortMonth = false}) {
+  const shortMonths = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  const longMonths = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  final months = shortMonth ? shortMonths : longMonths;
+  return '${months[date.month - 1]} ${date.day}, ${date.year}';
+}

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -158,6 +158,8 @@ Post _parseJekyllPost(String filePath, String filename, String content) {
     );
   }
 
+  final projectId = yaml['project']?.toString();
+
   return Post(
     permalink: permalink,
     title: title,
@@ -168,6 +170,7 @@ Post _parseJekyllPost(String filePath, String filename, String content) {
     isHtml: isHtml,
     uri: null,
     flavor: EntryFlavor.writing,
+    projectId: projectId,
   );
 }
 

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -9,7 +9,7 @@ import 'server/content_parser.dart';
 
 export 'models/data_model.dart';
 
-final List<Post> posts = _loadPosts();
+final List<Post> posts = List.unmodifiable(_loadPosts());
 
 List<Post> _loadPosts() {
   final postsList = <Post>[];

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -9,7 +9,7 @@ import 'server/content_parser.dart';
 
 export 'models/data_model.dart';
 
-List<Post> get posts => _loadPosts();
+final List<Post> posts = _loadPosts();
 
 List<Post> _loadPosts() {
   final postsList = <Post>[];

--- a/lib/models/data_model.dart
+++ b/lib/models/data_model.dart
@@ -14,25 +14,13 @@ enum EntryFlavor {
   };
 
   String get awesome {
-    String clazz;
-    String title;
-    switch (this) {
-      case EntryFlavor.youtube:
-        clazz = 'fab fa-youtube fa-2x';
-        title = 'YouTube';
-      case EntryFlavor.podcast:
-        clazz = 'fa fa-podcast fa-2x';
-        title = 'Podcast';
-      case EntryFlavor.calendar:
-        clazz = 'fa fa-calendar fa-2x';
-        title = 'Future event';
-      case EntryFlavor.writing:
-        clazz = 'fa fa-pencil-alt fa-2x';
-        title = 'Writing';
-      case EntryFlavor.link:
-        clazz = 'fa fa-link fa-2x';
-        title = 'Link';
-    }
+    final (clazz, title) = switch (this) {
+      EntryFlavor.youtube => ('fab fa-youtube fa-2x', 'YouTube'),
+      EntryFlavor.podcast => ('fa fa-podcast fa-2x', 'Podcast'),
+      EntryFlavor.calendar => ('fa fa-calendar fa-2x', 'Future event'),
+      EntryFlavor.writing => ('fa fa-pencil-alt fa-2x', 'Writing'),
+      EntryFlavor.link => ('fa fa-link fa-2x', 'Link'),
+    };
     return '<i class="$clazz" title="$title"></i>';
   }
 }
@@ -71,7 +59,6 @@ class Project {
   final String? installCommand;
   final bool featured;
   final bool ignore;
-  final List<String> relatedPostPermalinks;
   final String contentHtml;
   final String? latestVersion;
   final int? githubStars;
@@ -88,7 +75,6 @@ class Project {
     this.installCommand,
     this.featured = false,
     this.ignore = false,
-    this.relatedPostPermalinks = const [],
     required this.contentHtml,
     this.latestVersion,
     this.githubStars,

--- a/lib/models/data_model.dart
+++ b/lib/models/data_model.dart
@@ -47,6 +47,7 @@ class Post {
   final bool isHtml;
   final String? uri;
   final EntryFlavor flavor;
+  final String? projectId;
 
   Post({
     required this.permalink,
@@ -58,6 +59,7 @@ class Post {
     required this.isHtml,
     this.uri,
     required this.flavor,
+    this.projectId,
   });
 }
 

--- a/lib/pages/post_page.dart
+++ b/lib/pages/post_page.dart
@@ -123,7 +123,7 @@ class PostPage extends StatelessComponent {
                           'text-xs font-semibold text-slate-400 '
                           'px-2.5 py-0.5 border border-slate-200 '
                           'rounded-md',
-                      [Component.text(tag)],
+                      [Component.text(content.normalizeTag(tag))],
                     ),
                   ),
                 ]),

--- a/lib/pages/post_page.dart
+++ b/lib/pages/post_page.dart
@@ -98,20 +98,16 @@ class PostPage extends StatelessComponent {
               if (post.tags.isNotEmpty || project != null)
                 div(classes: 'flex items-center flex-wrap gap-x-2 gap-y-2', [
                   if (project != null)
-                    span(
+                    a(
+                      href: '/projects#${project.id}',
                       classes:
                           'text-xs font-semibold text-blue-600 '
                           'dark:text-blue-400 px-2.5 py-0.5 '
                           'border border-blue-200 '
                           'dark:border-blue-900 rounded-md '
-                          'bg-blue-50/50 dark:bg-blue-950/20',
-                      [
-                        a(
-                          href: '/projects#${project.id}',
-                          classes: 'hover:underline',
-                          [Component.text('Project: ${project.name}')],
-                        ),
-                      ],
+                          'bg-blue-50/50 dark:bg-blue-950/20 '
+                          'hover:underline',
+                      [Component.text('Project: ${project.name}')],
                     ),
                   ...post.tags.map(
                     (tag) => span(

--- a/lib/pages/post_page.dart
+++ b/lib/pages/post_page.dart
@@ -45,9 +45,7 @@ class PostPage extends StatelessComponent {
     final hasSubtitle = post.subTitle != null && post.subTitle!.isNotEmpty;
     final project = post.projectId == null
         ? null
-        : projects_content.projects
-              .where((proj) => proj.id == post.projectId)
-              .firstOrNull;
+        : projects_content.projectsById[post.projectId];
 
     return Component.fragment([
       Document.head(
@@ -100,7 +98,7 @@ class PostPage extends StatelessComponent {
                   [Component.text(post.subTitle!)],
                 ),
               if (post.tags.isNotEmpty || project != null)
-                div(classes: 'flex items-center space-x-2 flex-wrap gap-y-2', [
+                div(classes: 'flex items-center flex-wrap gap-x-2 gap-y-2', [
                   if (project != null)
                     span(
                       classes:

--- a/lib/pages/post_page.dart
+++ b/lib/pages/post_page.dart
@@ -41,7 +41,7 @@ class PostPage extends StatelessComponent {
       ]);
     }
 
-    final dateString = _formatDate(post.date);
+    final dateString = formatReadableDate(post.date);
     final hasSubtitle = post.subTitle != null && post.subTitle!.isNotEmpty;
     final project = post.projectId == null
         ? null
@@ -140,21 +140,3 @@ class PostPage extends StatelessComponent {
     ]);
   }
 }
-
-String _formatDate(DateTime date) =>
-    '${_months[date.month - 1]} ${date.day}, ${date.year}';
-
-const _months = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];

--- a/lib/pages/post_page.dart
+++ b/lib/pages/post_page.dart
@@ -43,9 +43,7 @@ class PostPage extends StatelessComponent {
 
     final dateString = formatReadableDate(post.date);
     final hasSubtitle = post.subTitle != null && post.subTitle!.isNotEmpty;
-    final project = post.projectId == null
-        ? null
-        : projects_content.projectsById[post.projectId];
+    final project = projects_content.projectsById[post.projectId];
 
     return Component.fragment([
       Document.head(

--- a/lib/pages/post_page.dart
+++ b/lib/pages/post_page.dart
@@ -5,6 +5,7 @@ import '../components/footer.dart';
 import '../components/header.dart';
 import '../constants.dart';
 import '../content.dart' as content;
+import '../projects_content.dart' as projects_content;
 
 class PostPage extends StatelessComponent {
   final String permalink;
@@ -14,13 +15,9 @@ class PostPage extends StatelessComponent {
   @override
   Component build(BuildContext context) {
     // Search for post by permalink
-    content.Post? post;
-    for (final p in content.posts) {
-      if (p.permalink == permalink) {
-        post = p;
-        break;
-      }
-    }
+    final post = content.posts
+        .where((entry) => entry.permalink == permalink)
+        .firstOrNull;
 
     // 404 fallback
     if (post == null) {
@@ -46,6 +43,11 @@ class PostPage extends StatelessComponent {
 
     final dateString = _formatDate(post.date);
     final hasSubtitle = post.subTitle != null && post.subTitle!.isNotEmpty;
+    final project = post.projectId == null
+        ? null
+        : projects_content.projects
+              .where((proj) => proj.id == post.projectId)
+              .firstOrNull;
 
     return Component.fragment([
       Document.head(
@@ -97,21 +99,34 @@ class PostPage extends StatelessComponent {
                       'font-medium leading-relaxed mb-6 italic',
                   [Component.text(post.subTitle!)],
                 ),
-              if (post.tags.isNotEmpty)
-                div(
-                  classes: 'flex items-center space-x-2',
-                  post.tags
-                      .map(
-                        (tag) => span(
-                          classes:
-                              'text-xs font-semibold text-slate-400 '
-                              'px-2.5 py-0.5 border border-slate-200 '
-                              'rounded-md',
-                          [Component.text(tag)],
+              if (post.tags.isNotEmpty || project != null)
+                div(classes: 'flex items-center space-x-2 flex-wrap gap-y-2', [
+                  if (project != null)
+                    span(
+                      classes:
+                          'text-xs font-semibold text-blue-600 '
+                          'dark:text-blue-400 px-2.5 py-0.5 '
+                          'border border-blue-200 '
+                          'dark:border-blue-900 rounded-md '
+                          'bg-blue-50/50 dark:bg-blue-950/20',
+                      [
+                        a(
+                          href: '/projects#${project.id}',
+                          classes: 'hover:underline',
+                          [Component.text('Project: ${project.name}')],
                         ),
-                      )
-                      .toList(),
-                ),
+                      ],
+                    ),
+                  ...post.tags.map(
+                    (tag) => span(
+                      classes:
+                          'text-xs font-semibold text-slate-400 '
+                          'px-2.5 py-0.5 border border-slate-200 '
+                          'rounded-md',
+                      [Component.text(tag)],
+                    ),
+                  ),
+                ]),
             ]),
 
             // Article Body (Beautiful Prose)

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -15,6 +15,14 @@ class ProjectsPage extends StatelessComponent {
   Component build(BuildContext context) {
     final allProjects = projects;
 
+    final postsByProject = <String, List<Post>>{};
+    for (final post in posts) {
+      final projectId = post.projectId;
+      if (projectId != null) {
+        postsByProject.putIfAbsent(projectId, () => []).add(post);
+      }
+    }
+
     return Component.fragment([
       const Document.head(
         children: [link(href: '$siteUrl/projects', rel: 'canonical')],
@@ -46,9 +54,7 @@ class ProjectsPage extends StatelessComponent {
               for (final project in allProjects)
                 ProjectCard(
                   project: project,
-                  relatedPosts: posts
-                      .where((post) => post.projectId == project.id)
-                      .toList(),
+                  relatedPosts: postsByProject[project.id] ?? const [],
                   key: ValueKey(project.id),
                 ),
             ]),

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -7,8 +7,9 @@ import '../models/data_model.dart';
 
 class ProjectsPage extends StatelessComponent {
   final List<Project> projects;
+  final List<Post> posts;
 
-  const ProjectsPage({required this.projects, super.key});
+  const ProjectsPage({required this.projects, required this.posts, super.key});
 
   @override
   Component build(BuildContext context) {
@@ -43,7 +44,13 @@ class ProjectsPage extends StatelessComponent {
 
             div(classes: 'grid grid-cols-1 gap-8', [
               for (final project in allProjects)
-                ProjectCard(project: project, key: ValueKey(project.id)),
+                ProjectCard(
+                  project: project,
+                  relatedPosts: posts
+                      .where((post) => post.projectId == project.id)
+                      .toList(),
+                  key: ValueKey(project.id),
+                ),
             ]),
           ]),
           const Footer(),
@@ -55,8 +62,13 @@ class ProjectsPage extends StatelessComponent {
 
 class ProjectCard extends StatelessComponent {
   final Project project;
+  final List<Post> relatedPosts;
 
-  const ProjectCard({required this.project, super.key});
+  const ProjectCard({
+    required this.project,
+    required this.relatedPosts,
+    super.key,
+  });
 
   @override
   Component build(BuildContext context) {
@@ -64,7 +76,7 @@ class ProjectCard extends StatelessComponent {
     final pubUrl = project.pubUrl;
     final githubUrl = project.githubUrl;
 
-    return div(classes: 'project-card', [
+    return div(id: project.id, classes: 'project-card', [
       div([
         div(classes: 'flex items-center justify-between gap-3 mb-2', [
           div(classes: 'project-metadata', [
@@ -92,6 +104,44 @@ class ProjectCard extends StatelessComponent {
         div(classes: 'prose prose-slate dark:prose-invert project-desc', [
           RawText(project.contentHtml),
         ]),
+        if (relatedPosts.isNotEmpty) ...[
+          div(
+            classes:
+                'mt-4 pt-4 border-t border-slate-100 '
+                'dark:border-slate-800/60',
+            [
+              const div(
+                classes:
+                    'text-xs font-semibold text-slate-400 '
+                    'dark:text-slate-500 uppercase tracking-wider mb-2',
+                [Component.text('Related Posts')],
+              ),
+              ul(classes: 'space-y-1.5', [
+                for (final post in relatedPosts)
+                  li(
+                    classes:
+                        'text-sm flex items-center '
+                        'justify-between gap-4',
+                    [
+                      a(
+                        href: post.permalink,
+                        classes:
+                            'hover:underline text-slate-700 '
+                            'dark:text-slate-200 font-medium flex-1',
+                        [Component.text(post.title)],
+                      ),
+                      span(
+                        classes:
+                            'text-xs font-mono text-slate-400 '
+                            'dark:text-slate-500 whitespace-nowrap',
+                        [Component.text(_formatDate(post.date))],
+                      ),
+                    ],
+                  ),
+              ]),
+            ],
+          ),
+        ],
       ]),
       div(classes: 'project-footer', [
         if (installCommand != null && installCommand.isNotEmpty)
@@ -133,4 +183,22 @@ class ProjectCard extends StatelessComponent {
       ]),
     ]);
   }
+}
+
+String _formatDate(DateTime date) {
+  final months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[date.month - 1]} ${date.day}, ${date.year}';
 }

--- a/lib/pages/projects_page.dart
+++ b/lib/pages/projects_page.dart
@@ -17,7 +17,7 @@ class ProjectsPage extends StatelessComponent {
 
     return Component.fragment([
       const Document.head(
-        children: [link(href: '$siteUrl/projects/', rel: 'canonical')],
+        children: [link(href: '$siteUrl/projects', rel: 'canonical')],
       ),
       div(
         classes:
@@ -134,7 +134,11 @@ class ProjectCard extends StatelessComponent {
                         classes:
                             'text-xs font-mono text-slate-400 '
                             'dark:text-slate-500 whitespace-nowrap',
-                        [Component.text(_formatDate(post.date))],
+                        [
+                          Component.text(
+                            formatReadableDate(post.date, shortMonth: true),
+                          ),
+                        ],
                       ),
                     ],
                   ),
@@ -183,22 +187,4 @@ class ProjectCard extends StatelessComponent {
       ]),
     ]);
   }
-}
-
-String _formatDate(DateTime date) {
-  final months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ];
-  return '${months[date.month - 1]} ${date.day}, ${date.year}';
 }

--- a/lib/projects_content.dart
+++ b/lib/projects_content.dart
@@ -1,10 +1,9 @@
 import 'dart:io';
 import 'package:path/path.dart' as p;
-import 'package:yaml/yaml.dart';
 import 'models/data_model.dart';
 import 'server/content_parser.dart';
 
-List<Project> get projects => _loadProjects();
+final List<Project> projects = _loadProjects();
 
 List<Project> _loadProjects() {
   final dir = Directory('_projects');
@@ -63,11 +62,6 @@ Project parseProjectFile(File file) {
     installCommand: installCmd,
     featured: yamlMap['featured'] == true,
     ignore: yamlMap['ignore'] == true,
-    relatedPostPermalinks:
-        (yamlMap['related_posts'] as YamlList?)
-            ?.map((e) => e.toString())
-            .toList() ??
-        const [],
     contentHtml: parsed.bodyHtml,
     latestVersion: yamlMap['version']?.toString(),
     githubStars: yamlMap['stars'] is int

--- a/lib/projects_content.dart
+++ b/lib/projects_content.dart
@@ -3,7 +3,11 @@ import 'package:path/path.dart' as p;
 import 'models/data_model.dart';
 import 'server/content_parser.dart';
 
-final List<Project> projects = _loadProjects();
+final List<Project> projects = List.unmodifiable(_loadProjects());
+
+final Map<String, Project> projectsById = Map.unmodifiable({
+  for (final project in projects) project.id: project,
+});
 
 List<Project> _loadProjects() {
   final dir = Directory('_projects');

--- a/test/content_test.dart
+++ b/test/content_test.dart
@@ -94,11 +94,10 @@ void main() {
         migrationPost.contentHtml,
       ).isNotNull().contains('migrated the entire blog to Dart and');
 
-      // Verify that project metadata is parsed
       final gitAliasPost = posts.firstWhere(
         (p) => p.title == 'Git aliases are awesome, even locally',
       );
-      check(gitAliasPost.projectId).equals('personal_dotfiles');
+      check(gitAliasPost.projectId).isNull();
     });
 
     test(

--- a/test/content_test.dart
+++ b/test/content_test.dart
@@ -92,6 +92,12 @@ void main() {
       check(
         migrationPost.contentHtml,
       ).isNotNull().contains('migrated the entire blog to Dart and');
+
+      // Verify that project metadata is parsed
+      final gitAliasPost = posts.firstWhere(
+        (p) => p.title == 'Git aliases are awesome, even locally',
+      );
+      check(gitAliasPost.projectId).equals('personal_dotfiles');
     });
 
     test('generateAtomFeed filters out appearances', () {

--- a/test/content_test.dart
+++ b/test/content_test.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:checks/checks.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:work_j832_com/content.dart';
 
@@ -98,6 +101,20 @@ void main() {
         (p) => p.title == 'Git aliases are awesome, even locally',
       );
       check(gitAliasPost.projectId).equals('personal_dotfiles');
+    });
+
+    test('Verify all post projectId references correspond to existing project '
+        'files', () {
+      final projectFiles = Directory('_projects')
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.md'))
+          .map((f) => p.basenameWithoutExtension(f.path))
+          .toSet();
+
+      for (final post in posts.where((p) => p.projectId != null)) {
+        check(projectFiles).contains(post.projectId!);
+      }
     });
 
     test('generateAtomFeed filters out appearances', () {

--- a/test/content_test.dart
+++ b/test/content_test.dart
@@ -1,9 +1,7 @@
-import 'dart:io';
-
 import 'package:checks/checks.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:work_j832_com/content.dart';
+import 'package:work_j832_com/projects_content.dart' as projects_content;
 
 void main() {
   group('Content System Tests', () {
@@ -103,19 +101,18 @@ void main() {
       check(gitAliasPost.projectId).equals('personal_dotfiles');
     });
 
-    test('Verify all post projectId references correspond to existing project '
-        'files', () {
-      final projectFiles = Directory('_projects')
-          .listSync()
-          .whereType<File>()
-          .where((f) => f.path.endsWith('.md'))
-          .map((f) => p.basenameWithoutExtension(f.path))
-          .toSet();
+    test(
+      'Verify all post projectId references correspond to active projects',
+      () {
+        final activeProjectIds = projects_content.projects
+            .map((p) => p.id)
+            .toSet();
 
-      for (final post in posts.where((p) => p.projectId != null)) {
-        check(projectFiles).contains(post.projectId!);
-      }
-    });
+        for (final post in posts.where((p) => p.projectId != null)) {
+          check(activeProjectIds).contains(post.projectId!);
+        }
+      },
+    );
 
     test('generateAtomFeed filters out appearances', () {
       final feedXml = generateAtomFeed();


### PR DESCRIPTION
## Overview
Adds support for associating blog posts with projects via a `project: <project_id>` field in post frontmatter.

## Key Changes
- **Data Model & Parser**: Added nullable `projectId` to `Post` and extracted `project` from markdown frontmatter.
- **Projects Page**: Forwarded posts to `ProjectsPage`, added anchor IDs to `ProjectCard`, and rendered related posts inline within each card.
- **Post Page**: Rendered a styled badge at the top of associated posts linking back to `/projects#<project_id>`.
- **Optimization & Cleanup**: Memoized top-level `posts` and `projects` collections to avoid redundant disk I/O, consolidated date formatting in `constants.dart`, normalized `/projects` canonical link, and modernized `EntryFlavor.awesome`.
- **Testing**: Added integrity test verifying all `post.projectId` references map to existing project markdown files.